### PR TITLE
Adding libv8-dev to .travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,8 @@ notifications:
   email:
     on_success: change
     on_failure: change
+
+addons:
+  apt:
+    packages:
+      - libv8-dev


### PR DESCRIPTION
Needed to add libv8-dev to .travis to allow Travis-CI to run given updated package in Suggests (`rstanarm` or dependency?)